### PR TITLE
chore: add paths to pullrequest and push triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,8 @@ name: CI
 on:
   push:
     branches: ["*"]
-    paths:
-      - "task_api/**"
   pull_request:
     branches: ["*"]
-    paths:
-      - "task_api/**"
 
 jobs:
   lint-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: ["*"]
+    paths:
+      - "task_api/**"
   pull_request:
     branches: ["*"]
+    paths:
+      - "task_api/**"
 
 jobs:
   lint-test:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,8 @@ name: Integration Tests
 on:
   pull_request:
     branches: ["main"]
+    paths:
+      - "task_api/**"
 
 jobs:
   compose-it:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to limit CI and integration test runs to changes affecting the `task_api` directory. This helps reduce unnecessary workflow runs and speeds up the development process.