### PR TITLE
Correct indentation in docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          image-ref: |
+          tags: |
             ${{ secrets.DOCKERHUB_USER }}/task-api-dev:${{ github.sha }}
             ${{ secrets.DOCKERHUB_USER }}/task-api-dev:latest
 


### PR DESCRIPTION
This pull request makes a small update to the Docker publish workflow configuration. The change replaces the deprecated `image-ref` field with the correct `tags` field in the `.github/workflows/docker-publish.yml` file. This ensures Docker images are tagged properly during the publishing process.