### PR TITLE
Update CI workflow to trigger on all paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ name: CI
 on:
   push:
     branches: ["*"]
-    paths:
-      - "task_api/**"
-      - "tests/unit/**"
   pull_request:
     branches: ["main"]
 


### PR DESCRIPTION
This pull request makes a small change to the CI workflow configuration. It removes the `paths` filter from the `push` trigger in `.github/workflows/ci.yml`, so CI will now run on all file changes, not just changes in `task_api/**` or `tests/unit/**`.Removed specific paths from push trigger in CI workflow.