### PR TITLE
Update CI workflow to target main branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["*"]
-    paths:
-      - "task_api/**"
-      - "tests/unit/**"
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 


### PR DESCRIPTION
This pull request makes a small but important change to the CI workflow configuration. The workflow will now only run on pushes to the `main` branch, instead of all branches and specific paths.

* The `push` trigger in `.github/workflows/ci.yml` is now limited to the `main` branch, removing the previous configuration that triggered on any branch and specific paths.Restrict CI workflow to only run on the main branch.