### PR TITLE
Add paths filter for Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,11 @@ name: Docker Publish
 on:
   push:
     branches: ["main"]
+    paths:
+      - "task_api/**"
+      - "Dockerfile"
+      - "requirements.txt"
+      
   release:
     types: [published]
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Docker publishing. The workflow will now only trigger on pushes to the `main` branch if the changes affect specific files or directories, making the build process more efficient.

Workflow trigger improvements:

* Updated the `docker-publish.yml` workflow to trigger only when files in `task_api/**`, `Dockerfile`, or `requirements.txt` are changed, in addition to the existing `main` branch restriction.